### PR TITLE
Use print() function in both Python 2 and Python 3

### DIFF
--- a/examples/grasping/grasp_samplers/grasp_predictor.py
+++ b/examples/grasping/grasp_samplers/grasp_predictor.py
@@ -16,6 +16,11 @@ n_class = 18
 min_patch_std = 1
 angle_dependence = [0.25, 0.5, 0.25]
 
+try:
+    xrange
+except NameError:
+    xrange = range
+
 
 # Given image, returns image point and theta to grasp
 class Predictors:

--- a/examples/sim2real/test.py
+++ b/examples/sim2real/test.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 # Copyright (c) Facebook, Inc. and its affiliates.
 
 # This source code is licensed under the MIT license found in the
@@ -41,9 +42,9 @@ def evaluate_policy(policy, eval_episodes=100):
 
     avg_reward /= eval_episodes
 
-    print "---------------------------------------"
-    print "Evaluation over %d episodes: %f" % (eval_episodes, avg_reward)
-    print "---------------------------------------"
+    print("---------------------------------------")
+    print("Evaluation over %d episodes: %f" % (eval_episodes, avg_reward))
+    print("---------------------------------------")
     return avg_reward
 
 


### PR DESCRIPTION
Legacy __print__ statements are syntax errors in Python 3 but __print()__ function works as expected in both Python 2 and Python 3.

[flake8](http://flake8.pycqa.org) testing of https://github.com/facebookresearch/pyrobot on Python 3.7.1

$ __flake8 . --count --select=E9,F63,F72,F82 --show-source --statistics__
```
./setup.py:29:13: F821 undefined name '__version__'
    version=__version__,
            ^
./examples/sim2real/train.py:24:14: F821 undefined name 'xrange'
    for _ in xrange(eval_episodes):
             ^
./examples/sim2real/train.py:117:85: F821 undefined name 'episode_timesteps'
                                                                                    episode_timesteps, episode_reward))
                                                                                    ^
./examples/sim2real/train.py:117:104: F821 undefined name 'episode_reward'
                                                                                    episode_timesteps, episode_reward))
                                                                                                       ^
./examples/sim2real/train.py:118:45: F821 undefined name 'episode_timesteps'
                policy.train(replay_buffer, episode_timesteps, args.batch_size, args.discount, args.tau,
                                            ^
./examples/sim2real/test.py:44:51: E999 SyntaxError: invalid syntax
    print "---------------------------------------"
                                                  ^
./examples/grasping/grasp_samplers/grasp_predictor.py:89:23: F821 undefined name 'xrange'
        for looper in xrange(num_samples):
                      ^
./examples/grasping/grasp_samplers/grasp_predictor.py:123:23: F821 undefined name 'xrange'
        for looper in xrange(num_samples):
                      ^
./examples/grasping/grasp_samplers/grasp_predictor.py:124:32: F821 undefined name 'xrange'
            for norm_looper in xrange(n_class):
                               ^
./src/pyrobot/locobot/base_controllers.py:484:21: F632 use ==/!= to compare str, bytes, and int literals
                    self.execution_status is not 4), \
                    ^
./src/pyrobot/locobot/base_controllers.py:486:16: F632 use ==/!= to compare str, bytes, and int literals
            if self.execution_status is 3:
               ^
1     E999 SyntaxError: invalid syntax
2     F632 use ==/!= to compare str, bytes, and int literals
8     F821 undefined name 'xrange'
11
```
__E901,E999,F821,F822,F823__ are the "_showstopper_" [flake8](http://flake8.pycqa.org) issues that can halt the runtime with a SyntaxError, NameError, etc. These 5 are different from most other flake8 issues which are merely "style violations" -- useful for readability but they do not effect runtime safety.
* F821: undefined name `name`
* F822: undefined name `name` in `__all__`
* F823: local variable name referenced before assignment
* E901: SyntaxError or IndentationError
* E999: SyntaxError -- failed to compile a file into an Abstract Syntax Tree
