### PR TITLE
Add version requirement for pytz

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -14,3 +14,4 @@ yacs==0.1.6
 guzzle-sphinx-theme==0.7.11
 mock==3.0.5
 pyassimp
+pytz>=2015.7


### PR DESCRIPTION
Although following installation in the docs, `pip install .` shows an error message

```
ERROR: babel 2.7.0 has requirement pytz>=2015.7, but you'll have pytz 2014.10 which is incompatible.
```

This is on `Ubuntu 16.04`.  So it should also follow the installation docs. `lsb_release -a`:

```
No LSB modules are available.
Distributor ID: Ubuntu
Description:    Ubuntu 16.04.6 LTS
Release:        16.04
Codename:       xenial
```

So I guess it is better to add version requirement for `pytz` to solve it.