### PR TITLE
Update installation docs to add recurse-submodules parameter

### DIFF
--- a/docs/website/docs/gs_software.md
+++ b/docs/website/docs/gs_software.md
@@ -55,7 +55,7 @@ cd ~
 mkdir -p low_cost_ws/src
 cd ~/low_cost_ws/src
 source ~/${virtualenv_name}/bin/activate
-git clone https://github.com/facebookresearch/pyrobot.git
+git clone --recurse-submodules https://github.com/facebookresearch/pyrobot.git
 cd pyrobot
 pip install .
 ```


### PR DESCRIPTION

This updates the docs at https://www.pyrobot.org/docs/software.

I followed above steps to install but after soon I found some submodules are not cloned. To be consistent with README on https://github.com/facebookresearch/pyrobot, it should be better to add `recurse-submodules` parameter.

