### PR TITLE
Publish wheel joint states for LoCoBot

### DIFF
--- a/robots/LoCoBot/locobot_description/urdf/locobot_description.urdf
+++ b/robots/LoCoBot/locobot_description/urdf/locobot_description.urdf
@@ -941,6 +941,7 @@
             <odometryTopic>odom</odometryTopic> 
             <odometryFrame>odom</odometryFrame> 
             <robotBaseFrame>base_footprint</robotBaseFrame> 
+            <publishWheelJointState>true</publishWheelJointState>
         </plugin>   
         <plugin filename="libgazebo_ros_p3d.so" name="p3d_base_controller"> 
             <alwaysOn>true</alwaysOn>   

--- a/robots/LoCoBot/locobot_gazebo/src/gazebo_locobot_control.cpp
+++ b/robots/LoCoBot/locobot_gazebo/src/gazebo_locobot_control.cpp
@@ -174,9 +174,15 @@ void GazeboInteface::goalJointPositionCallback(const sensor_msgs::JointState::Co
 }
 
 void GazeboInteface::recordArmJoints(const sensor_msgs::JointState::ConstPtr & msg) {
-    for (int index = 0; index < 7; ++index)
-        arm_state[index] = msg->position.at(index + 2); //the index of arm joints starts at 2
-    //ROS_INFO("Recording joint Angles!");
+    int msgSize = msg->position.size();
+    if (msgSize == 9) {
+        for (int index = 0; index < 7; ++index)
+            arm_state[index] = msg->position.at(index + 2); //the index of arm joints starts at 2
+    } else if (msgSize == 2) {
+        // wheel joint states
+    } else {
+        ROS_INFO("Invalid joint state, aborted");
+    }
 }
 
 void GazeboInteface::stopExecution(const std_msgs::Empty & msg) {


### PR DESCRIPTION
Current `locobot_description.urdf` produces continuously a warning message, when playing with Gazebo `roslaunch locobot_control main.launch use_base:=true use_sim:=true`, due to lack of wheel joint states:

```
[ WARN] [1562649444.627024800, 12.304000000]: The complete state of the robot is not yet known.  Missing wheel_left_joint, wheel_right_joint
[ WARN] [1562649446.125726300, 13.304000000]: The complete state of the robot is not yet known.  Missing wheel_left_joint, wheel_right_joint
[ WARN] [1562649447.761487900, 14.317000000]: The complete state of the robot is not yet known.  Missing wheel_left_joint, wheel_right_joint
[ WARN] [1562649449.274219500, 15.404000000]: The complete state of the robot is not yet known.  Missing wheel_left_joint, wheel_right_joint
...
```

This patch adds a config to publish wheel joint states.