### PR TITLE
allow physics config passthrough in Habitat backend

### DIFF
--- a/src/pyrobot/habitat/simulator.py
+++ b/src/pyrobot/habitat/simulator.py
@@ -12,12 +12,15 @@ class HabitatSim(object):
     """Class that interfaces with Habitat sim"""
 
     def __init__(
-        self, configs, scene_path=None, seed=0
+            self, configs, scene_path=None, physics_config=None, seed=0
     ):  # TODO: extend the arguments of constructor
         self.sim_config = copy.deepcopy(configs.COMMON.SIMULATOR)
         self.sim_config.defrost()
         if scene_path is not None:
             self.sim_config.SCENE_ID = scene_path
+        if physics_config is not None:
+            self.sim_config.PHYSICS_CONFIG_FILE = physics_config
+            self.sim_config.PHYSICS = True
         self.sim = habitat_sim.Simulator(make_cfg(self.sim_config))
         self.set_seed(seed)  # TODO: Not working!! Check with abhishek
         print(self.sim_config)


### PR DESCRIPTION
Fairly simple addition, it allows one to pass through custom physics configurations as well