### PR TITLE
Hyperlink to LICENSE file added in README.md and CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -81,4 +81,4 @@ The python code uses [Flake8](https://pypi.org/project/flake8/) style. [autopep8
 
 ## License
 By contributing to **PyRobot**, you agree that your contributions will be licensed
-under the LICENSE file in the root directory of this source tree.
+under the **[LICENSE](https://github.com/facebookresearch/pyrobot/blob/master/LICENSE)** file in the root directory of this source tree.

--- a/README.md
+++ b/README.md
@@ -100,4 +100,4 @@ We are planning several features, namely:
 }
 ```
 ## License
-PyRobot is under MIT license, as found in the LICENSE file.
+PyRobot is under MIT license, as found in the **[LICENSE](https://github.com/facebookresearch/pyrobot/blob/master/LICENSE)** file.


### PR DESCRIPTION
## Motivation and Context
License information for the code is at the end of the README file. To view the LICENSE file, one has to scroll all the way. 
Hence adding a hyperlink in the README.md file is preferred.

## How Has This Been Tested
Action: Clicking on LICENSE hyperlink in README.md and CONTRIBUTING.md
Verify: Hyperlink is working and user is navigated to the LICENSE file.
## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x ] I have read the **CONTRIBUTING** document.
- [x ] I have completed my CLA (see **CONTRIBUTING**)
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.