### PR TITLE
fixed camera matrix, fetch point cloud in habitat, minor bug fix

### DIFF
--- a/examples/habitat/example1.py
+++ b/examples/habitat/example1.py
@@ -26,7 +26,8 @@ bot = Robot("habitat", common_config=common_config)
 visualize(bot)
 
 # Execute an action on the base to move forward
-bot.base.execute_action("move_forward")
+distance = 0.1  # in meter
+bot.base.execute_action("move_forward", actuation=distance)
 print("Move forward using discreate actions")
 visualize(bot)
 

--- a/examples/habitat/visualize_pcd.py
+++ b/examples/habitat/visualize_pcd.py
@@ -1,0 +1,26 @@
+from pyrobot import Robot
+
+import os
+import open3d
+
+
+# Please change this to match your habitat_sim repo's path
+path_to_habitat_scene = os.path.dirname(os.path.realpath(__file__))
+relative_path = "scenes/skokloster-castle.glb"
+
+common_config = dict(scene_path=os.path.join(path_to_habitat_scene, relative_path))
+bot = Robot("habitat", common_config=common_config)
+
+# fetch the point
+pts, colors = bot.camera.get_current_pcd(in_cam=False)
+
+# convert points to open3d point cloud object
+pcd = open3d.PointCloud()
+pcd.points = open3d.Vector3dVector(pts)
+pcd.colors = open3d.Vector3dVector(colors / 255.0)
+
+# for visualizing the origin
+coord = open3d.create_mesh_coordinate_frame(1, [0, 0, 0])
+
+# visualize point cloud
+open3d.visualization.draw_geometries([pcd, coord])

--- a/robots/LoCoBot/locobot_navigation/orb_slam2_ros/cfg/realsense_habitat.yaml
+++ b/robots/LoCoBot/locobot_navigation/orb_slam2_ros/cfg/realsense_habitat.yaml
@@ -4,8 +4,8 @@
 # Camera Parameters. Adjust them!
 #--------------------------------------------------------------------------------------------
 
-Camera.fx: 1000
-Camera.fy: 1000
+Camera.fx: 256
+Camera.fy: 256
 Camera.cx: 256
 Camera.cy: 256
 

--- a/src/pyrobot/habitat/camera.py
+++ b/src/pyrobot/habitat/camera.py
@@ -37,6 +37,7 @@ class LoCoBotCamera(object):
         # Pan and tilt related vairades.
         self.pan = 0.0
         self.tilt = 0.0
+        self.agent.initial_state = self.agent.get_state()
 
     def get_rgb(self):
         observations = self.sim.get_sensor_observations()
@@ -57,10 +58,10 @@ class LoCoBotCamera(object):
 		:return: the intrinsic matrix (shape: :math:`[3, 3]`)
 		:rtype: np.ndarray
 		"""
-        fx = self.configs['Camera.fx']
-        fy = self.configs['Camera.fy']
-        cx = self.configs['Camera.cx']
-        cy = self.configs['Camera.cy']
+        fx = self.depth_cam.cfg_data['Camera.fx']
+        fy = self.depth_cam.cfg_data['Camera.fy']
+        cx = self.depth_cam.cfg_data['Camera.cx']
+        cy = self.depth_cam.cfg_data['Camera.cy']
         Itc = np.array([[fx, 0, cx], [0, fy, cy], [0, 0, 1]])
         return Itc
 
@@ -108,28 +109,50 @@ class LoCoBotCamera(object):
         if in_cam:
             return pts, colors
 
-        # here, points are now given in camera frame
-        # the thing to do next is to transform the points from camera frame into the
-        # global frame of pyrobot environment
-        # This does not translate to what habitat thinks as origin,
-        # because pyrobot's habitat-reference origin is `self.agent.init_state`
-        # So, CAMERA frame -> HABITAT frame -> PYROBOT frame
+        pts = self._cam2pyrobot(pts, initial_rotation=initial_rotation)
+        return pts, colors
 
-        init_state = self.agent.initial_state # habitat - x,y,z
+
+    def _cam2pyrobot(self, pts, initial_rotation=None):
+        """
+        here, points are  given in camera frame
+        the thing to do next is to transform the points from camera frame into the
+        global frame of pyrobot environment
+        This does not translate to what habitat thinks as origin,
+        because pyrobot's habitat-reference origin is `self.agent.init_state`
+        So, CAMERA frame -> HABITAT frame -> PYROBOT frame
+        :param pts: point coordinates in camera frame
+                  (shape: :math:`[N, 3]`)
+        :param initial_rotation: a known initial rotation of the camera sensor
+                                 to calibrate habitat origin. The default value
+                                 is None which means it uses the Habitat-reported
+                                 value.
+
+        :type pts: np.ndarray
+        :type initial_rotation: float
+
+        :returns: pts
+
+                  pts: point coordinates in world frame
+                  (shape: :math:`[N, 3]`)
+
+        :rtype: np.ndarray
+        """
+
+        init_state = self.agent.initial_state  # habitat - x,y,z
         cur_state = self.agent.get_state()
         cur_sensor_state = cur_state.sensor_states['rgb']
         if initial_rotation is None:
             initial_rotation = init_state.sensor_states['rgb'].rotation
         rot_init_rotation = self._rot_matrix(initial_rotation)
 
+        ros_to_habitat_frame = np.array([[0.0, -1.0, 0.0],
+                                         [0.0, 0.0, 1.0],
+                                         [-1.0, 0.0, 0.0]])
 
-        ros_to_habitat_frame = np.array([[ 0.0, -1.0,  0.0],
-                                         [ 0.0,  0.0,  1.0],
-                                         [-1.0,  0.0,  0.0]])
-
-        camera_to_image_frame = np.array([[1.0,  0.0,  0.0],
-                                          [0.0, -1.0,  0.0],
-                                          [0.0,  0.0, -1.0]])
+        camera_to_image_frame = np.array([[1.0, 0.0, 0.0],
+                                          [0.0, -1.0, 0.0],
+                                          [0.0, 0.0, -1.0]])
 
         relative_position = cur_sensor_state.position - init_state.position
         relative_position = rot_init_rotation.T @ relative_position
@@ -144,8 +167,7 @@ class LoCoBotCamera(object):
         pts = pts + relative_position
         pts = ros_to_habitat_frame.T @ pts.T
         pts = pts.T
-        return pts, colors
-
+        return pts
 
     def _rot_matrix(self, habitat_quat):
         quat_list = [habitat_quat.x, habitat_quat.y, habitat_quat.z, habitat_quat.w]
@@ -167,8 +189,13 @@ class LoCoBotCamera(object):
 		          colors: rgb values for pts_in_cam (shape: :math:`[N, 3]`)
 		:rtype: tuple(np.ndarray, np.ndarray)
 		"""
-
-        raise NotImplementedError
+        rgb_im, depth_im = self.get_rgb_depth()
+        pcd_in_cam, colors = self.depth_cam.get_pcd_ic(depth_im=depth_im, rgb_im=rgb_im)
+        pts = pcd_in_cam[:3, :].T
+        if in_cam:
+            return pts, colors
+        pts = self._cam2pyrobot(pts)
+        return pts, colors
 
     @property
     def state(self):
@@ -240,7 +267,6 @@ class LoCoBotCamera(object):
         self.set_pan_tilt(self.pan, tilt)
 
     def _compute_relative_pose(self, pan, tilt):
-
         pan_link = 0.1  # length of pan link
         tilt_link = 0.1  # length of tilt link
 


### PR DESCRIPTION
## Motivation and Context

- Added `get_current_pcd` in habitat backend
- Fixed camera matrix used in habitat backend. 
  - With current camera matrix [(video)](https://www.youtube.com/watch?v=u80ErLc89c8&feature=youtu.be)
    - robot location is projected below the ground
    - walls which are perpendicular are coming out to be at an angle
  - With updated camera matrix, which is calculated based on the `fov` and `resolution` values which are being stored in the habitat simulator state, above mentioned issues are resolved [(video)](https://youtu.be/RjvrI78beEk)

## How Has This Been Tested

- To check camera matrix, tried to visualize point cloud

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.