### PR TITLE
bug fix

### DIFF
--- a/src/pyrobot/habitat/base.py
+++ b/src/pyrobot/habitat/base.py
@@ -38,7 +38,7 @@ class LoCoBotBase(object):
 
     def get_state(self, state_type="odom"):
         # Returns (x, y, yaw)
-        assert state_type == "odom", "Error: Only Odom state is availalabe"
+        assert state_type == "odom", "Error: Only Odom state is available"
         cur_state = self.get_full_state()
 
         init_rotation = self._rot_matrix(self.init_state.rotation)
@@ -152,10 +152,14 @@ class LoCoBotBase(object):
             return False
 
         (cur_x, cur_y, cur_yaw) = self.get_state()
-        rel_x = xyt_position[0] - cur_x
-        rel_y = xyt_position[1] - cur_y
+        rel_X = xyt_position[0] - cur_x
+        rel_Y = xyt_position[1] - cur_y
         abs_yaw = xyt_position[2]
-        return self._go_to_relative_pose(rel_x, rel_y, abs_yaw)
+        # convert rel_X & rel_Y from global frame to  current frame
+        R = np.array([[np.cos(cur_yaw), np.sin(cur_yaw)],
+                      [-np.sin(cur_yaw), np.cos(cur_yaw)]])
+        rel_x, rel_y = np.matmul(R, np.array([rel_X, rel_Y]).reshape(-1,1))
+        return self._go_to_relative_pose(rel_x[0], rel_y[0], abs_yaw)
 
     def _act(self, action_name, actuation):
         """Take the action specified by action_id


### PR DESCRIPTION
## Motivation and Context

- There is transformation issue in `go_to_absolute` function in `habitat` wrapper
- Currently `pix_to_3dpt` & `get_current_pcd` function in `habitat` wrapper returns point in global frame while in `locobot`, it returns it in robot base frame 

## How Has This Been Tested

- For `go_to_absolute` function, it has been tested using the testcase
- For `pix_to_3dpt` & `get_current_pcd` has been tested based on the visualization

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.