### PR TITLE
Newest pip drop py2 support

### DIFF
--- a/robots/LoCoBot/install/locobot_install_all.sh
+++ b/robots/LoCoBot/install/locobot_install_all.sh
@@ -107,7 +107,7 @@ install_packages "${package_names[@]}"
 
 sudo pip install --upgrade cryptography
 sudo python -m easy_install --upgrade pyOpenSSL
-sudo pip install --upgrade pip
+sudo pip install --upgrade pip==20.3
 
 
 # STEP 2 - Install ROS 


### PR DESCRIPTION
## Motivation and Context

Thanks to issue #144, swiz23 pointed out that the newest version of pip has dropped support for py2, which breaks the install.

## How Has This Been Tested

CircleCI, plus test install on clean machine.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.